### PR TITLE
change toJSONAPI to use more separate functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "JSON API implementation using Bookshelf models",
   "main": "yus-jsonapi.js",
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^3.10.1"
+  },
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- changes it to use many smaller functions instead of fewer inlined functions
- introduces 'links' on resources (w/ support for additional links defined in models)
- doesn't exclude relationships when using "?include" query param
- hopefully doesn't break anything!
